### PR TITLE
diddyreader.monkey:  set graphicsPath on LoadMap

### DIFF
--- a/src/diddy/tile/diddyreader.monkey
+++ b/src/diddy/tile/diddyreader.monkey
@@ -26,6 +26,10 @@ Class DiddyTiledTileMapReader Extends TileMapReader
 		' create parser and get root node
 		Local parser:XMLParser = New XMLParser
 		doc = parser.ParseString(xmlString)
+
+		'Set the root graphics path relative to this file's location.
+		graphicsPath = _ExtractDir(filename) + "/"
+		
 		Return ReadMap(doc.Root)
 	End
 	
@@ -283,3 +287,9 @@ Function _StripDir$( path$ )
 	Return path
 End
 
+' taken from brl.filepath
+Function _ExtractDir:String( path:String )
+	Local i=path.FindLast( "/" )
+	If i=-1 i=path.FindLast( "\" )
+	If i<>-1 Return path[..i]
+End


### PR DESCRIPTION
Note:  _StripDir doesn't appear to be used, but ExtractDir is used here.  To avoid brl.filepath import, I've thrown the function into this file.  However, I don't see an issue with using brl.filepath in general.  Feel free to refactor/clean this up as you see fit.

Other notes:  I couldn't find anything that actually set graphicsPath anywhere in the original code.  What?