### PR TITLE
Make XML load with mojo as using os isn't working for Desktop target.

### DIFF
--- a/src/diddy/xml.monkey
+++ b/src/diddy/xml.monkey
@@ -23,7 +23,8 @@ Import diddy.constants
 ' only import os or mojo if LoadString is enabled
 #If XML_USE_LOADSTRING
 	' import os if LoadString is implemented there, otherwise import mojo
-	#If TARGET="stdcpp" Or TARGET="glfw"
+	#If TARGET="stdcpp" 
+	' Or TARGET="glfw"
 		Import os
 	#Else
 		Import mojo


### PR DESCRIPTION
the define XML_USE_LOADSTRING = true is still required.
